### PR TITLE
Don't show deprecated specs in menu

### DIFF
--- a/_includes/spec_menu.html
+++ b/_includes/spec_menu.html
@@ -1,7 +1,7 @@
 <span class="dropdown">{{ include.menu_name }}
 	<div class="dropdown-content">
 		<p><b>{{ include.menu_title }}</b></p>
-		{% assign specs_to_show = site.data.specs | where_exp:"spec", "spec.amwa_id contains include.filter_id" | where: "show_in_index", true %}
+		{% assign specs_to_show = site.data.specs | where_exp:"spec", "spec.amwa_id contains include.filter_id" | where_exp: "spec", "spec.status != 'Deprecated'" | where: "show_in_index", true %}
 		{% for spec in specs_to_show %}
 			<p><a href="{{ spec.url }}">{{ spec.amwa_id }}: {{ spec.name }}</a></p>
 		{% endfor %}


### PR DESCRIPTION
The "IS", "BCP" etc menus are generated from a Liquid template -- filtering out ones whose status is "Deprecated". It makes sense not to show them in the menus but list them on the main index.